### PR TITLE
Phase 0: Introduce ItemData as generic inventory base type

### DIFF
--- a/Assets/_Project/Scripts/Core/IInventory.cs
+++ b/Assets/_Project/Scripts/Core/IInventory.cs
@@ -1,9 +1,9 @@
-using UnityEngine;
+using CultivationGame.Data;
 
 namespace CultivationGame.Core
 {
     public interface IInventory
     {
-        void AddItem(ScriptableObject item);
+        void AddItem(ItemData item);
     }
 }

--- a/Assets/_Project/Scripts/Data/DataTemplates/EssenceData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/EssenceData.cs
@@ -3,14 +3,9 @@ using UnityEngine;
 namespace CultivationGame.Data
 {
     [CreateAssetMenu(fileName = "NewEssence", menuName = "Cultivation/Essence Data")]
-    public class EssenceData : ScriptableObject
+    public class EssenceData : ItemData
     {
         public string essenceName;
-        public string description;
-        public int qiValue;
         public Color essenceColor = Color.white;
-        public Sprite icon;
-
-        public GameObject collectionEffect;
     }
 }

--- a/Assets/_Project/Scripts/Data/DataTemplates/ItemData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/ItemData.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace CultivationGame.Data
+{
+    public enum ItemType
+    {
+        Essence,
+        Pill,
+        RawMaterial
+    }
+
+    public abstract class ItemData : ScriptableObject
+    {
+        public string description;
+        public int qiValue;
+        public Sprite icon;
+        public GameObject collectionEffect;
+        public ItemType itemType;
+    }
+}

--- a/Assets/_Project/Scripts/Player/Inventory/PlayerInventory.cs
+++ b/Assets/_Project/Scripts/Player/Inventory/PlayerInventory.cs
@@ -9,19 +9,19 @@ namespace CultivationGame.Player
     {
         public PlayerStats playerStats;
 
-        private Dictionary<EssenceData, int> items = new Dictionary<EssenceData, int>();
+        private Dictionary<ItemData, int> items = new Dictionary<ItemData, int>();
 
-        public void AddItem(ScriptableObject item)
+        public void AddItem(ItemData item)
         {
-            if (item is not EssenceData essence || essence == null) return;
+            if (item == null) return;
 
-            if (items.ContainsKey(essence))
+            if (items.ContainsKey(item))
             {
-                items[essence]++;
+                items[item]++;
             }
             else
             {
-                items.Add(essence, 1);
+                items.Add(item, 1);
             }
 
             GameEvents.RaiseInventoryChanged();
@@ -45,14 +45,14 @@ namespace CultivationGame.Player
             GameEvents.RaiseInventoryChanged();
         }
 
-        public Dictionary<EssenceData, int> GetItems()
+        public Dictionary<ItemData, int> GetItems()
         {
             return items;
         }
 
-        public void LoadInventory(Dictionary<EssenceData, int> loaded)
+        public void LoadInventory(Dictionary<ItemData, int> loaded)
         {
-            items = new Dictionary<EssenceData, int>(loaded);
+            items = new Dictionary<ItemData, int>(loaded);
             GameEvents.RaiseInventoryChanged();
         }
     }

--- a/Assets/_Project/Scripts/Ui/Inventory/InventoryDisplay.cs
+++ b/Assets/_Project/Scripts/Ui/Inventory/InventoryDisplay.cs
@@ -14,7 +14,7 @@ namespace CultivationGame.UI
 
         private readonly List<InventorySlotDisplay> _activeSlots = new();
 
-        public void RefreshDisplay(Dictionary<EssenceData, int> items)
+        public void RefreshDisplay(Dictionary<ItemData, int> items)
         {
             int index = 0;
             foreach (var entry in items)
@@ -31,7 +31,10 @@ namespace CultivationGame.UI
                     slot = go.GetComponent<InventorySlotDisplay>();
                     _activeSlots.Add(slot);
                 }
-                slot.Setup(entry.Key, entry.Value, playerInventory.UseEssence);
+                slot.Setup(entry.Key, entry.Value, item =>
+                {
+                    if (item is EssenceData e) playerInventory.UseEssence(e);
+                });
                 index++;
             }
 

--- a/Assets/_Project/Scripts/Ui/Inventory/InventorySlotDisplay.cs
+++ b/Assets/_Project/Scripts/Ui/Inventory/InventorySlotDisplay.cs
@@ -19,10 +19,10 @@ namespace CultivationGame.UI
             if (button == null) button = gameObject.AddComponent<Button>();
         }
 
-        public void Setup(EssenceData data, int amount, Action<EssenceData> onUse)
+        public void Setup(ItemData data, int amount, Action<ItemData> onUse)
         {
             iconImage.sprite = data.icon;
-            iconImage.color = data.essenceColor;
+            iconImage.color = data is EssenceData essence ? essence.essenceColor : Color.white;
 
             if (amountText != null)
                 amountText.text = amount > 1 ? amount.ToString() : "";

--- a/Assets/_Project/Scripts/Ui/Save/SaveManager.cs
+++ b/Assets/_Project/Scripts/Ui/Save/SaveManager.cs
@@ -19,7 +19,7 @@ namespace CultivationGame.UI
 
         [Header("Data References")]
         public List<RealmDefinition> allRealms;
-        public List<EssenceData> allEssences;
+        public List<ItemData> allItems;
 
         public static SaveManager Instance { get; private set; }
 
@@ -130,11 +130,11 @@ namespace CultivationGame.UI
             }
 
             // Restore inventory
-            var loaded = new Dictionary<EssenceData, int>();
+            var loaded = new Dictionary<ItemData, int>();
             foreach (var entry in data.inventoryEntries)
             {
-                var essence = allEssences?.Find(e => e.name == entry.essenceId);
-                if (essence != null) loaded[essence] = entry.count;
+                var item = allItems?.Find(i => i.name == entry.essenceId);
+                if (item != null) loaded[item] = entry.count;
             }
             playerInventory.LoadInventory(loaded);
         }


### PR DESCRIPTION
Add abstract ItemData ScriptableObject with shared fields (description, qiValue, icon, collectionEffect, itemType) and ItemType enum. EssenceData now inherits from ItemData, removing duplicated fields while preserving all serialized field names so existing .asset files load without migration.

Update IInventory, PlayerInventory, InventoryDisplay, InventorySlotDisplay, and SaveManager to use ItemData generically. EssenceData-specific logic (essenceColor, UseEssence) is preserved via type-safe downcasts.

Note: SaveManager.allEssences renamed to allItems — Inspector list must be re-wired manually after this commit.

https://claude.ai/code/session_019wvMhwo3j65sbkAAtrwqQL