### PR TITLE
Phase 1: Add PillData, RawMaterialData, and RecipeData ScriptableObjects

### DIFF
--- a/Assets/_Project/Scripts/Data/DataTemplates/PillData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/PillData.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace CultivationGame.Data
+{
+    public enum PillGrade { Mortal, Earth, Heaven, Divine }
+
+    [CreateAssetMenu(fileName = "NewPill", menuName = "Cultivation/Pill Data")]
+    public class PillData : ItemData
+    {
+        public string pillName;
+        public Color pillColor = Color.white;
+        public PillGrade grade;
+    }
+}

--- a/Assets/_Project/Scripts/Data/DataTemplates/RawMaterialData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/RawMaterialData.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace CultivationGame.Data
+{
+    [CreateAssetMenu(fileName = "NewRawMaterial", menuName = "Cultivation/Raw Material Data")]
+    public class RawMaterialData : ItemData
+    {
+        public string materialName;
+        public Color materialColor = Color.white;
+    }
+}

--- a/Assets/_Project/Scripts/Data/DataTemplates/RecipeData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/RecipeData.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CultivationGame.Data
+{
+    [Serializable]
+    public struct RecipeIngredient
+    {
+        public ItemData item;
+        public int amount;
+    }
+
+    [CreateAssetMenu(fileName = "NewRecipe", menuName = "Cultivation/Recipe Data")]
+    public class RecipeData : ScriptableObject
+    {
+        public string recipeName;
+        public List<RecipeIngredient> ingredients;
+        public ItemData outputItem;
+        public int outputAmount = 1;
+        public float craftingDuration;
+    }
+}


### PR DESCRIPTION
Introduce the three data-layer types needed for the alchemy factory system:

- PillData: ItemData subtype with pillName, pillColor, PillGrade enum (Mortal/Earth/Heaven/Divine). qiValue inherited from ItemData.
- RawMaterialData: ItemData subtype with materialName, materialColor. Intentionally minimal; expansions come in later phases.
- RecipeData: ScriptableObject with serializable RecipeIngredient list (item + amount), outputItem (ItemData), outputAmount, craftingDuration. Ready for consumption by a future CraftingSystem.

No changes to existing files — AddItem(ItemData) and allItems list already accept the new types without modification.

https://claude.ai/code/session_019wvMhwo3j65sbkAAtrwqQL