### PR TITLE
Fix assembly circular dependency: move data-typed events to Game.Data

### DIFF
--- a/Assets/_Project/Scripts/Core/GameEvents.cs
+++ b/Assets/_Project/Scripts/Core/GameEvents.cs
@@ -1,5 +1,3 @@
-using CultivationGame.Data;
-
 namespace CultivationGame.Core
 {
     public static class GameEvents
@@ -57,32 +55,5 @@ namespace CultivationGame.Core
         public static event MeditationBonusApplied OnMeditationBonusApplied;
         public static void RaiseMeditationBonusApplied(float multiplier)
             => OnMeditationBonusApplied?.Invoke(multiplier);
-
-        // --- Crafting ---
-        public delegate void CraftingStarted(RecipeData recipe);
-        public static event CraftingStarted OnCraftingStarted;
-        public static void RaiseCraftingStarted(RecipeData recipe)
-            => OnCraftingStarted?.Invoke(recipe);
-
-        public delegate void CraftingCompleted(RecipeData recipe);
-        public static event CraftingCompleted OnCraftingCompleted;
-        public static void RaiseCraftingCompleted(RecipeData recipe)
-            => OnCraftingCompleted?.Invoke(recipe);
-
-        public delegate void CraftingFailed(RecipeData recipe);
-        public static event CraftingFailed OnCraftingFailed;
-        public static void RaiseCraftingFailed(RecipeData recipe)
-            => OnCraftingFailed?.Invoke(recipe);
-
-        // --- Pills ---
-        public delegate void PillConsumed(PillData pill);
-        public static event PillConsumed OnPillConsumed;
-        public static void RaisePillConsumed(PillData pill)
-            => OnPillConsumed?.Invoke(pill);
-
-        public delegate void PillEffectsApplied(PillData pill, float effectiveness);
-        public static event PillEffectsApplied OnPillEffectsApplied;
-        public static void RaisePillEffectsApplied(PillData pill, float effectiveness)
-            => OnPillEffectsApplied?.Invoke(pill, effectiveness);
     }
 }

--- a/Assets/_Project/Scripts/Data/GameDataEvents.cs
+++ b/Assets/_Project/Scripts/Data/GameDataEvents.cs
@@ -1,0 +1,32 @@
+namespace CultivationGame.Data
+{
+    public static class GameDataEvents
+    {
+        // --- Crafting ---
+        public delegate void CraftingStarted(RecipeData recipe);
+        public static event CraftingStarted OnCraftingStarted;
+        public static void RaiseCraftingStarted(RecipeData recipe)
+            => OnCraftingStarted?.Invoke(recipe);
+
+        public delegate void CraftingCompleted(RecipeData recipe);
+        public static event CraftingCompleted OnCraftingCompleted;
+        public static void RaiseCraftingCompleted(RecipeData recipe)
+            => OnCraftingCompleted?.Invoke(recipe);
+
+        public delegate void CraftingFailed(RecipeData recipe);
+        public static event CraftingFailed OnCraftingFailed;
+        public static void RaiseCraftingFailed(RecipeData recipe)
+            => OnCraftingFailed?.Invoke(recipe);
+
+        // --- Pills ---
+        public delegate void PillConsumed(PillData pill);
+        public static event PillConsumed OnPillConsumed;
+        public static void RaisePillConsumed(PillData pill)
+            => OnPillConsumed?.Invoke(pill);
+
+        public delegate void PillEffectsApplied(PillData pill, float effectiveness);
+        public static event PillEffectsApplied OnPillEffectsApplied;
+        public static void RaisePillEffectsApplied(PillData pill, float effectiveness)
+            => OnPillEffectsApplied?.Invoke(pill, effectiveness);
+    }
+}

--- a/Assets/_Project/Scripts/Player/Inventory/PlayerInventory.cs
+++ b/Assets/_Project/Scripts/Player/Inventory/PlayerInventory.cs
@@ -34,7 +34,7 @@ namespace CultivationGame.Player
             items[pill]--;
             if (items[pill] <= 0) items.Remove(pill);
 
-            GameEvents.RaisePillConsumed(pill);
+            GameDataEvents.RaisePillConsumed(pill);
             GameEvents.RaiseInventoryChanged();
         }
 

--- a/Assets/_Project/Scripts/Systems/Crafting/CraftingSystem.cs
+++ b/Assets/_Project/Scripts/Systems/Crafting/CraftingSystem.cs
@@ -48,7 +48,7 @@ namespace CultivationGame.Systems
         private IEnumerator CraftCoroutine(RecipeData recipe, Action<bool> onComplete)
         {
             _isCrafting = true;
-            GameEvents.RaiseCraftingStarted(recipe);
+            GameDataEvents.RaiseCraftingStarted(recipe);
 
             if (recipe.craftingDuration > 0f)
                 yield return new WaitForSeconds(recipe.craftingDuration);
@@ -67,11 +67,11 @@ namespace CultivationGame.Systems
                     for (int i = 0; i < output.amount; i++)
                         playerInventory.AddItem(output.item);
 
-                GameEvents.RaiseCraftingCompleted(recipe);
+                GameDataEvents.RaiseCraftingCompleted(recipe);
             }
             else
             {
-                GameEvents.RaiseCraftingFailed(recipe);
+                GameDataEvents.RaiseCraftingFailed(recipe);
             }
 
             _isCrafting = false;

--- a/Assets/_Project/Scripts/Systems/Pill/PillBuffSystem.cs
+++ b/Assets/_Project/Scripts/Systems/Pill/PillBuffSystem.cs
@@ -24,8 +24,8 @@ namespace CultivationGame.Systems
             if (Instance == null) Instance = this;
         }
 
-        private void OnEnable()  => GameEvents.OnPillConsumed += HandlePillConsumed;
-        private void OnDisable() => GameEvents.OnPillConsumed -= HandlePillConsumed;
+        private void OnEnable()  => GameDataEvents.OnPillConsumed += HandlePillConsumed;
+        private void OnDisable() => GameDataEvents.OnPillConsumed -= HandlePillConsumed;
 
         private void HandlePillConsumed(PillData pill)
         {
@@ -49,7 +49,7 @@ namespace CultivationGame.Systems
             if (pill.breakthroughBonus > 0f && pill.buffDuration > 0f)
                 StartCoroutine(ApplyBreakthroughBuff(pill.breakthroughBonus, pill.buffDuration, effectiveness));
 
-            GameEvents.RaisePillEffectsApplied(pill, effectiveness);
+            GameDataEvents.RaisePillEffectsApplied(pill, effectiveness);
         }
 
         private IEnumerator ApplySpeedBuff(float multiplier, float duration, float effectiveness)

--- a/Assets/_Project/Scripts/Ui/Crafting/CraftingUI.cs
+++ b/Assets/_Project/Scripts/Ui/Crafting/CraftingUI.cs
@@ -36,17 +36,17 @@ namespace CultivationGame.UI
         private void Awake()
         {
             GameEvents.OnInventoryChanged  += OnInventoryChanged;
-            GameEvents.OnCraftingStarted   += OnCraftingStarted;
-            GameEvents.OnCraftingCompleted += OnCraftingDone;
-            GameEvents.OnCraftingFailed    += OnCraftingDone;
+            GameDataEvents.OnCraftingStarted   += OnCraftingStarted;
+            GameDataEvents.OnCraftingCompleted += OnCraftingDone;
+            GameDataEvents.OnCraftingFailed    += OnCraftingDone;
         }
 
         private void OnDestroy()
         {
             GameEvents.OnInventoryChanged  -= OnInventoryChanged;
-            GameEvents.OnCraftingStarted   -= OnCraftingStarted;
-            GameEvents.OnCraftingCompleted -= OnCraftingDone;
-            GameEvents.OnCraftingFailed    -= OnCraftingDone;
+            GameDataEvents.OnCraftingStarted   -= OnCraftingStarted;
+            GameDataEvents.OnCraftingCompleted -= OnCraftingDone;
+            GameDataEvents.OnCraftingFailed    -= OnCraftingDone;
         }
 
         public void Open()


### PR DESCRIPTION
RecipeData and PillData live in Game.Data, which already references Game.Core, making it impossible for Game.Core to reference them back.

- Create GameDataEvents.cs in Game.Data with crafting and pill events
- Remove those events from GameEvents.cs (Game.Core) along with the now-unneeded `using CultivationGame.Data` import
- Update CraftingSystem, CraftingUI, PlayerInventory, PillBuffSystem to use GameDataEvents instead of GameEvents for these events