### PR TITLE
Fix assembly error: move IInventory to Game.Data

### DIFF
--- a/Assets/_Project/Scripts/Core/IInventory.cs
+++ b/Assets/_Project/Scripts/Core/IInventory.cs
@@ -1,9 +1,1 @@
-using CultivationGame.Data;
-
-namespace CultivationGame.Core
-{
-    public interface IInventory
-    {
-        void AddItem(ItemData item);
-    }
-}
+// Moved to CultivationGame.Data — see Assets/_Project/Scripts/Data/IInventory.cs

--- a/Assets/_Project/Scripts/Data/IInventory.cs
+++ b/Assets/_Project/Scripts/Data/IInventory.cs
@@ -1,0 +1,7 @@
+namespace CultivationGame.Data
+{
+    public interface IInventory
+    {
+        void AddItem(ItemData item);
+    }
+}


### PR DESCRIPTION
IInventory references ItemData (Game.Data) but lived in Game.Core, which has no reference to Game.Data — and can't, as Game.Data already depends on Game.Core. Move the interface to Game.Data where it belongs. All implementors (PlayerInventory) and usages (EssenceSpawner, SpiritEssence) already import CultivationGame.Data so no caller changes are needed.