### PR TITLE
Fix: stable itemId for saves and atomic save writes

### DIFF
--- a/Assets/_Project/Scripts/Data/DataTemplates/ItemData.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/ItemData.cs
@@ -11,6 +11,12 @@ namespace CultivationGame.Data
 
     public abstract class ItemData : ScriptableObject
     {
+        [SerializeField, Tooltip("Stable save ID — set once, never rename. Falls back to asset name if empty.")]
+        private string itemId;
+
+        /// <summary>Stable identifier used for save/load. Falls back to the asset's file name.</summary>
+        public string ItemId => string.IsNullOrEmpty(itemId) ? name : itemId;
+
         public string description;
         public int qiValue;
         public Sprite icon;

--- a/Assets/_Project/Scripts/Systems/Save/SaveSystem.cs
+++ b/Assets/_Project/Scripts/Systems/Save/SaveSystem.cs
@@ -7,20 +7,43 @@ namespace CultivationGame.Systems
     public static class SaveSystem
     {
         private static string SavePath => Path.Combine(Application.persistentDataPath, "cultivator_save.json");
+        private static string TempPath => SavePath + ".tmp";
 
         public static void SaveGame(SaveData data)
         {
-            string json = JsonUtility.ToJson(data, true);
-            File.WriteAllText(SavePath, json);
-            Debug.Log($"Spiel gespeichert unter: {SavePath}");
+            try
+            {
+                string json = JsonUtility.ToJson(data, true);
+
+                // Write to temp file first, then rename atomically
+                // so a crash mid-write never corrupts the existing save.
+                File.WriteAllText(TempPath, json);
+                if (File.Exists(SavePath)) File.Delete(SavePath);
+                File.Move(TempPath, SavePath);
+
+                Debug.Log($"Spiel gespeichert unter: {SavePath}");
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError($"Speichern fehlgeschlagen: {e.Message}");
+                if (File.Exists(TempPath)) File.Delete(TempPath);
+            }
         }
 
         public static SaveData LoadGame()
         {
             if (!File.Exists(SavePath)) return null;
 
-            string json = File.ReadAllText(SavePath);
-            return JsonUtility.FromJson<SaveData>(json);
+            try
+            {
+                string json = File.ReadAllText(SavePath);
+                return JsonUtility.FromJson<SaveData>(json);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError($"Laden fehlgeschlagen: {e.Message}");
+                return null;
+            }
         }
 
         public static void DeleteSave()

--- a/Assets/_Project/Scripts/Ui/Save/SaveManager.cs
+++ b/Assets/_Project/Scripts/Ui/Save/SaveManager.cs
@@ -46,7 +46,7 @@ namespace CultivationGame.UI
             };
 
             foreach (var kvp in playerInventory.GetItems())
-                data.inventoryEntries.Add(new InventorySaveEntry { essenceId = kvp.Key.name, count = kvp.Value });
+                data.inventoryEntries.Add(new InventorySaveEntry { essenceId = kvp.Key.ItemId, count = kvp.Value });
 
             // World state
             data.collectedEssenceIds = new List<string>(WorldState.CollectedIds);
@@ -133,7 +133,7 @@ namespace CultivationGame.UI
             var loaded = new Dictionary<ItemData, int>();
             foreach (var entry in data.inventoryEntries)
             {
-                var item = allItems?.Find(i => i.name == entry.essenceId);
+                var item = allItems?.Find(i => i.ItemId == entry.essenceId);
                 if (item != null) loaded[item] = entry.count;
             }
             playerInventory.LoadInventory(loaded);


### PR DESCRIPTION
- ItemData: add private `itemId` field with public `ItemId` property; falls back to asset file name if empty, so existing assets work without migration. Set once in the Inspector, never rename.
- SaveManager: use ItemId instead of item.name for inventory save entries (both write and read side), making saves resilient to asset renames
- SaveSystem: atomic write via temp file + rename so a crash mid-write can never corrupt the existing save file; both Save and Load wrapped in try-catch with Debug.LogError on failure

https://claude.ai/code/session_019wvMhwo3j65sbkAAtrwqQL