### PR TITLE
Single-camera architecture: SpiritSenseCamera drives MainCamera directly

### DIFF
--- a/Assets/_Project/Scripts/Player/Camera/CameraSystem.cs
+++ b/Assets/_Project/Scripts/Player/Camera/CameraSystem.cs
@@ -84,7 +84,6 @@ namespace CultivationGame.Player
 
         private IEnumerator TransitionToSpiritSense()
         {
-            // Capture current action camera state
             Vector3 startPos = _mainCamera.transform.position;
             Quaternion startRot = _mainCamera.transform.rotation;
             float currentYaw = _mainCamera.transform.eulerAngles.y;
@@ -92,61 +91,47 @@ namespace CultivationGame.Player
             // Disable Cinemachine so we can manually drive the main camera
             cinemachineBrain.enabled = false;
 
-            // Initialize spirit sense target
-            spiritSenseCamera.Initialize(playerTransform.position, currentYaw);
+            // Initialize spirit sense — it will drive _mainCamera.transform from now on
+            spiritSenseCamera.Initialize(_mainCamera.transform, playerTransform.position, currentYaw);
             var (endPos, endRot) = spiritSenseCamera.GetCurrentState();
 
             // Animate the main camera from action pose to spirit sense pose
             yield return AnimateCamera(_mainCamera.transform, startPos, startRot, endPos, endRot);
 
-            // Switch: disable main camera, enable spirit sense camera
-            _mainCamera.enabled = false;
+            // Spirit sense takes over driving the main camera
             spiritSenseCamera.SetEnabled(true);
-            SetCameraTag(_mainCamera.gameObject, false);
-            SetCameraTag(spiritSenseCamera.gameObject, true);
-            GameEvents.RaiseActiveCameraChanged(spiritSenseCamera.GetCamera());
 
             // Input: disable Player map, re-enable Meditate, enable BuildMode
             _playerMap?.Disable();
             _meditateAction?.Enable();
             _buildModeMap?.Enable();
 
-            // Free cursor for build mode
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
         }
 
         private IEnumerator TransitionToAction()
         {
-            // Capture spirit sense camera state
             var (startPos, startRot) = spiritSenseCamera.GetCurrentState();
 
-            // Disable spirit sense camera
+            // Spirit sense stops driving the camera
             spiritSenseCamera.SetEnabled(false);
-            SetCameraTag(spiritSenseCamera.gameObject, false);
-
-            // Enable main camera for rendering during transition
-            _mainCamera.enabled = true;
-            SetCameraTag(_mainCamera.gameObject, true);
 
             // Compute a reasonable end position behind the player
-            // (Cinemachine will smooth from here when re-enabled)
             Vector3 endPos = ComputeActionCameraPosition();
             Quaternion endRot = Quaternion.LookRotation(
                 playerTransform.position + Vector3.up * 1.5f - endPos);
 
-            // Animate from spirit sense position back toward action position
+            // Animate back toward action position
             yield return AnimateCamera(_mainCamera.transform, startPos, startRot, endPos, endRot);
 
             // Re-enable Cinemachine — it blends smoothly from current transform
             cinemachineBrain.enabled = true;
-            GameEvents.RaiseActiveCameraChanged(_mainCamera);
 
             // Input: disable BuildMode, enable full Player map
             _buildModeMap?.Disable();
             _playerMap?.Enable();
 
-            // Lock cursor for action mode
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
         }
@@ -169,16 +154,9 @@ namespace CultivationGame.Player
 
         private Vector3 ComputeActionCameraPosition()
         {
-            // Place camera behind and above the player at a reasonable default distance
             Vector3 playerPos = playerTransform.position;
             Vector3 back = -playerTransform.forward;
             return playerPos + back * 5f + Vector3.up * 2f;
-        }
-
-        private void SetCameraTag(GameObject go, bool isMain)
-        {
-            if (go == null) return;
-            go.tag = isMain ? "MainCamera" : "Untagged";
         }
     }
 }

--- a/Assets/_Project/Scripts/Player/Camera/SpiritSenseCamera.cs
+++ b/Assets/_Project/Scripts/Player/Camera/SpiritSenseCamera.cs
@@ -32,17 +32,12 @@ namespace CultivationGame.Player
         private float _yaw;
         private float _pitch;
         private float _currentZoom;
-        private Camera _camera;
+        private Transform _target;
         private bool _isActive;
-
-        private void Awake()
-        {
-            _camera = GetComponent<Camera>();
-        }
 
         private void LateUpdate()
         {
-            if (!_isActive) return;
+            if (!_isActive || _target == null) return;
 
             HandlePan();
             HandleOrbit();
@@ -56,8 +51,8 @@ namespace CultivationGame.Player
             Vector2 input = panAction.action.ReadValue<Vector2>();
             if (input.sqrMagnitude < 0.01f) return;
 
-            Vector3 flatForward = new Vector3(transform.forward.x, 0f, transform.forward.z).normalized;
-            Vector3 flatRight = new Vector3(transform.right.x, 0f, transform.right.z).normalized;
+            Vector3 flatForward = new Vector3(_target.forward.x, 0f, _target.forward.z).normalized;
+            Vector3 flatRight = new Vector3(_target.right.x, 0f, _target.right.z).normalized;
             Vector3 panDelta = (flatForward * input.y + flatRight * input.x) * panSpeed * Time.deltaTime;
             _focalPoint += panDelta;
         }
@@ -87,12 +82,13 @@ namespace CultivationGame.Player
         {
             Quaternion rotation = Quaternion.Euler(_pitch, _yaw, 0f);
             Vector3 offset = rotation * new Vector3(0f, 0f, -_currentZoom);
-            transform.position = _focalPoint + offset;
-            transform.LookAt(_focalPoint);
+            _target.position = _focalPoint + offset;
+            _target.LookAt(_focalPoint);
         }
 
-        public void Initialize(Vector3 playerPosition, float playerYaw)
+        public void Initialize(Transform target, Vector3 playerPosition, float playerYaw)
         {
+            _target = target;
             _focalPoint = playerPosition;
             _yaw = playerYaw;
             _pitch = initialPitch;
@@ -103,20 +99,17 @@ namespace CultivationGame.Player
         public void SetEnabled(bool enabled)
         {
             _isActive = enabled;
-            if (_camera != null)
-                _camera.enabled = enabled;
         }
 
         public (Vector3 position, Quaternion rotation) GetCurrentState()
         {
-            return (transform.position, transform.rotation);
+            if (_target == null) return (transform.position, transform.rotation);
+            return (_target.position, _target.rotation);
         }
 
         public void SetElevation(float y)
         {
             _focalPoint.y = y;
         }
-
-        public Camera GetCamera() => _camera;
     }
 }

--- a/Assets/_Project/Scripts/Player/Movement/PlayerMovement.cs
+++ b/Assets/_Project/Scripts/Player/Movement/PlayerMovement.cs
@@ -66,14 +66,12 @@ namespace CultivationGame.Player
         {
             jump.action.performed += HandleJump;
             GameEvents.OnMeditationToggled += HandleMeditationBlock;
-            GameEvents.OnActiveCameraChanged += HandleCameraChanged;
         }
 
         private void OnDisable()
         {
             jump.action.performed -= HandleJump;
             GameEvents.OnMeditationToggled -= HandleMeditationBlock;
-            GameEvents.OnActiveCameraChanged -= HandleCameraChanged;
         }
 
         private void Update()
@@ -221,11 +219,6 @@ namespace CultivationGame.Player
                 groundCheckRadius,
                 groundLayer
             );
-        }
-
-        private void HandleCameraChanged(UnityEngine.Camera newCamera)
-        {
-            _camera = newCamera;
         }
 
         private void HandleMeditationBlock(bool isMeditating)


### PR DESCRIPTION
Eliminates the redundant two-camera swap. The MainCamera (with CinemachineBrain) stays active throughout — SpiritSenseCamera now receives the main camera's Transform via Initialize() and drives it directly in LateUpdate when active.

- SpiritSenseCamera: replaced self-transform + Camera field with injectable _target Transform; HandlePan reads _target.forward/right so panning orientation stays correct
- CameraSystem: removed all tag-swapping, Camera enable/disable, and RaiseActiveCameraChanged calls — no longer needed
- PlayerMovement: dropped OnActiveCameraChanged subscription since Camera.main identity never changes

https://claude.ai/code/session_019Xd8CL3wwCpkfhrWFp1VeQ