### PR TITLE
Remove dead RPG remnants (inner world, dao, combat, sect, buff types)

### DIFF
--- a/Assets/_Project/Scripts/Core/GameEnums.cs
+++ b/Assets/_Project/Scripts/Core/GameEnums.cs
@@ -2,42 +2,8 @@ namespace CultivationGame.Core
 {
     public enum GameState
     {
-        MainMenu,
         Playing,
-        Paused,
-        Meditating,
-        InBreakthrough,
-        InCombat
-    }
-
-    public enum RealmSubStage
-    {
-        None,
-        I, II, III, IV, V, VI, VII, VIII, IX,
-        Initial, Middle, Peak
-    }
-
-    public enum DaoType
-    {
-        Martial,
-        Sword,
-        Alchemy,
-        Arrays,
-        Lightning,
-        Wind,
-        Beast,
-        Divination,
-        Time,
-        Space,
-        Fate,
-        Chaos,
-        Creation
-    }
-
-    public enum DaoCategory
-    {
-        Basic,
-        Advanced
+        Paused
     }
 
     public enum BiomeType
@@ -50,72 +16,6 @@ namespace CultivationGame.Core
         StoneMountain,
         SpiritForest,
         CelestialPeak
-    }
-
-    public enum POIType
-    {
-        Sect,
-        Ruin,
-        SpiritBeastDen,
-        TreasureCache,
-        MysticPortal,
-        AncientStele,
-        Resource,
-        BuildingDiscovery
-    }
-
-    public enum TerrainType
-    {
-        Water,
-        Land,
-        Mountain
-    }
-
-    public enum InnerWorldTileType
-    {
-        Void,
-        DivineSea,
-        SpiritLake,
-        Water,
-        SpiritSoil,
-        FertileEarth,
-        SacredGrove,
-        Land,
-        StonePeak,
-        CelestialPeak,
-        Mountain
-    }
-
-    public enum BuildingTerrain
-    {
-        Water,
-        Land,
-        Mountain
-    }
-
-    public enum BuildingRarity
-    {
-        Common,
-        Uncommon,
-        Rare,
-        Epic,
-        Legendary
-    }
-
-    public enum SectRank
-    {
-        OuterDisciple,
-        InnerDisciple,
-        CoreDisciple,
-        Elder,
-        GrandElder
-    }
-
-    public enum BuffType
-    {
-        QiBoost,
-        Speed,
-        Vision
     }
 
     public enum MachineType

--- a/Assets/_Project/Scripts/Core/GameEvents.cs
+++ b/Assets/_Project/Scripts/Core/GameEvents.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace CultivationGame.Core
 {
     public static class GameEvents
@@ -69,12 +67,6 @@ namespace CultivationGame.Core
         public static event InteractPromptChanged OnInteractPromptChanged;
         public static void RaiseInteractPromptChanged(bool visible)
             => OnInteractPromptChanged?.Invoke(visible);
-
-        // --- Camera ---
-        public delegate void ActiveCameraChanged(Camera activeCamera);
-        public static event ActiveCameraChanged OnActiveCameraChanged;
-        public static void RaiseActiveCameraChanged(Camera cam)
-            => OnActiveCameraChanged?.Invoke(cam);
 
         // --- Build Elevation ---
         public delegate void BuildLayerChanged(int layer, float worldY);

--- a/Assets/_Project/Scripts/Data/DataTemplates/RealmDefinition.cs
+++ b/Assets/_Project/Scripts/Data/DataTemplates/RealmDefinition.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using CultivationGame.Core;
 
 namespace CultivationGame.Data
 {
@@ -9,7 +8,6 @@ namespace CultivationGame.Data
         [Header("Identity")]
         public string realmName;
         public int realmIndex;
-        public RealmSubStage subStage;
         [TextArea] public string description;
 
         [Header("Qi Requirements")]
@@ -19,8 +17,5 @@ namespace CultivationGame.Data
 
         [Header("Progression")]
         public RealmDefinition nextRealm;
-
-        [Header("Combat")]
-        public float baseCombatPower;
     }
 }


### PR DESCRIPTION
Deleted 10 unused enums from GameEnums.cs (DaoType, DaoCategory, POIType, TerrainType, InnerWorldTileType, BuildingTerrain, BuildingRarity, SectRank, BuffType, RealmSubStage). Trimmed GameState to Playing/Paused — the other values were never set or read.

Removed dead fields from RealmDefinition (subStage, baseCombatPower) and the now-subscriber-free OnActiveCameraChanged event from GameEvents.

BiomeType and MachineType are kept — both are core to the factory builder direction.

https://claude.ai/code/session_019Xd8CL3wwCpkfhrWFp1VeQ