### PR TITLE
Add TODO.md, consolidate open tasks from GAMEPLAN and PROJECT_STRUCTURE

### DIFF
--- a/Assets/_Project/PROJECT_STRUCTURE.md
+++ b/Assets/_Project/PROJECT_STRUCTURE.md
@@ -518,15 +518,5 @@ Each machine type needs a prefab with the appropriate component:
 ---
 
 ## Future Work
-- **Pipe Connection UI**: Visual interface for selecting source/destination machines for SpiritPipe, Splitter, Merger
-- **Save/Load Integration**: Implement serialization for Splitter/Merger connections using the existing SaveData entries
-- **Visual Pipes**: Line renderers or mesh generation between connected machines
-- **Throughput Upgrades**: Increase `itemsPerTransfer` or decrease `transferInterval` via upgrades
-- **Minor Realm Resource Adaptation**: Add resource spawning to MinorRealmConfig (Phase 6, Schritt 13)
-- **3rd Person Build Cursor**: Fine-tune cursor visibility + camera look interaction in 3rd person build mode
-- **Build Menu UI Styling**: Optimize build menu overlay for 3rd person perspective
-- **CameraSystem Inspector Setup**: Assign `playerStats` reference and `BuildToggle` InputActionReference in the Inspector
-- **PlacementController Inspector Setup**: Verify Place, Cancel, Rotate, Remove input references in the Inspector
-- **NPC System**: Phase 7 — NPCs, dialogue, quests
-- **Combat System**: Phase 8 — Minimal viable combat
-- **Progression & Story**: Phase 9 — Quest chains, unlock progression, win condition
+
+→ Siehe `Assets/_Project/TODO.md`

--- a/Assets/_Project/TODO.md
+++ b/Assets/_Project/TODO.md
@@ -1,0 +1,92 @@
+# Prison Realm: Alchemy Factory — Offene Aufgaben
+
+Letzte Aktualisierung: 2026-03-26
+Vollständige Liste aller offenen Punkte. GitHub Issues werden mit Copilot-Agents bearbeitet.
+Manuelle TODOs müssen im Unity-Editor erledigt werden.
+
+---
+
+## Manuelle TODOs (Unity-Editor)
+
+*Entspricht GitHub Issue #76*
+
+- [ ] CameraSystem Inspector: `playerStats` Referenz zuweisen
+- [ ] CameraSystem Inspector: `BuildToggle` InputActionReference auf `Player/BuildToggle` setzen
+- [ ] PlacementController Inspector: Input-Referenzen prüfen (Place, Cancel, Rotate, Remove)
+- [ ] Cursor-Handling in 3rd Person Build-Modus testen
+- [ ] Build-Menu UI-Styling für 3rd Person Overlay optimieren
+
+---
+
+## GitHub Issues (Copilot-Agent Tasks)
+
+### Phase 7: NPC & Quest System
+
+| Issue | Titel | Hängt von |
+|-------|-------|-----------|
+| #102 | QuestData ScriptableObject & QuestSystem | — |
+| #103 | NPCController MonoBehaviour | NPCData (✅ existiert) |
+| #104 | Quest-Journal UI | #102 |
+| #105 | Händler-System: ShopData & UI | NPCData |
+
+### Phase 9: Story & Endgame
+
+| Issue | Titel | Hängt von |
+|-------|-------|-----------|
+| #106 | StoryData, StoryProgressSystem & Win-Condition | #102 |
+| #112 | Realm-Breaking Pill Produktionskette | — |
+
+### Systems & Scenes
+
+| Issue | Titel | Hängt von |
+|-------|-------|-----------|
+| #107 | SceneTransitionManager | — |
+| #108 | Tutorial-System | — |
+| #109 | Hauptmenü-Scene | — |
+| #110 | Kompass-HUD | — |
+| #111 | Inventar-Tooltips & Rechtsklick-Kontextmenü | — |
+
+### Tests
+
+| Issue | Titel | Hängt von |
+|-------|-------|-----------|
+| #114 | Unit Tests: QiNetwork BFS | — |
+| #115 | Unit Tests: BaseMachine Pipeline | — |
+| #116 | Unit Tests: SaveSystem | — |
+
+### Qualität
+
+| Issue | Titel | Hängt von |
+|-------|-------|-----------|
+| #113 | Game Balance Pass | alle Content-Assets |
+| #117 | Code-Qualität Review | — |
+
+---
+
+## Kleinere technische TODOs (noch kein GitHub Issue)
+
+- [ ] **Save/Load für Splitter/Merger-Verbindungen**: Verbindungen werden aktuell nicht in SaveData serialisiert — auf Scene-Reload gehen Pipe-Verbindungen verloren
+- [ ] **Visual Pipes**: Line Renderer oder Mesh-Generierung zwischen verbundenen Maschinen zur visuellen Darstellung der Logistics-Netzwerke
+- [ ] **Throughput Upgrades**: `itemsPerTransfer` erhöhen / `transferInterval` senken via Upgrade-System (Post-Core-Loop Feature)
+
+---
+
+## Erledigte Punkte (Referenz)
+
+✅ Phase 6: Minor Realm Ressourcen-Spawning (PR #60, #62)
+✅ Phase 8: Combat System (PR #18, #19)
+✅ Pipe Connection UI (PR #41)
+✅ MachineData Assets alle 11 Typen (PR #40)
+✅ 3rd Person Build Cursor (PR #79)
+✅ QiNetwork Performance Dirty-Flag (PR #69)
+✅ BreakthroughSystem + UI (PR #78)
+✅ SoundManager + SoundEventTrigger (PR #84)
+✅ HUD: Qi/HP/Stamina + Buff Icons (PR #81)
+✅ RecipeDatabase Editor-Tool (PR #82)
+✅ LootSystem + EnemyData Assets (PR #80, #89)
+✅ MachineInspectUI (PR #77)
+✅ FactoryDashboardUI (PR #99)
+✅ NPCData + DialogueNode + DialogueUI (PR #90, #92, #59)
+✅ Unit Tests: MachineInventory, RecipeData, RecipeDatabase, LootSystem
+✅ Doppeltes .asmdef entfernt
+✅ 36 fehlende .meta-Dateien generiert

--- a/GAMEPLAN.md
+++ b/GAMEPLAN.md
@@ -565,53 +565,6 @@ SCHRITT 15: [Phase 9] Balancing + Win-Condition         ⬜ OFFEN
 
 ---
 
-## MANUELLE TODOs
+## TODOs
 
-- [x] RealmDefinition-Assets aktualisieren: `spiritSenseRange` Werte gesetzt (Mortal: 30, QiRefinement1: 40, QiRefinement2: 50, QiRefinement3: 60, QiRefinement4: 70, QiRefinement5: 80)
-- [ ] CameraSystem Inspector: `playerStats` Referenz zuweisen
-- [ ] CameraSystem Inspector: `BuildToggle` InputActionReference auf Player/BuildToggle setzen
-- [ ] PlacementController Inspector: Input-Referenzen prüfen (Place, Cancel, Rotate, Remove)
-- [x] Splitter/Merger Maschinen implementiert (`Systems/Factory/Splitter.cs`, `Systems/Factory/Merger.cs`)
-- [ ] Cursor-Handling in 3rd Person Build-Modus testen (Cursor sichtbar + Kamera-Look ggf. einschränken)
-- [ ] Build-Menu UI-Styling für 3rd Person Overlay optimieren
-
----
-
-## ORDNER-STRUKTUR (erweitert)
-
-```
-Assets/_Project/Scripts/
-├── Core/                    (bestehend + neue Events/Enums)
-├── Data/
-│   └── DataTemplates/
-│       ├── ItemData.cs      ✅ implementiert
-│       ├── PillData.cs      ✅ implementiert
-│       ├── RecipeData.cs    ✅ implementiert
-│       ├── MachineData.cs   ✅ implementiert
-│       ├── NPCData.cs       ⬜ offen (Phase 7)
-│       ├── QuestData.cs     ⬜ offen (Phase 7)
-│       ├── EnemyData.cs     ✅ implementiert (Phase 8)
-│       ├── EssenceData.cs   ✅ Subclass von ItemData
-│       └── RealmDefinition.cs  ✅ mit spiritSenseRange
-├── Player/                  (bestehend + Pill-Consumption)
-├── Systems/
-│   ├── Crafting/            ✅ CraftingSystem.cs
-│   ├── Factory/             ✅ BaseMachine, SpiritPipe, StorageContainer, Splitter, Merger, QiNetwork, QiConduit, OreVein, ResourceExtractor
-│   ├── Building/            ✅ BuildGrid, PlacementController
-│   ├── NPC/                 ⬜ offen (Phase 7)
-│   ├── Quest/               ⬜ offen (Phase 7)
-│   ├── Combat/              ✅ implementiert (Phase 8)│   ├── Pill/                ✅ PillBuffSystem.cs
-│   ├── Realm/               (bestehend)
-│   ├── Essence/             (bestehend)
-│   ├── Save/                (bestehend + erweitert)
-│   └── Interaction/         (bestehend)
-└── Ui/
-    ├── Crafting/            ✅ CraftingController.cs
-    ├── Factory/             ✅ MachineUIController.cs
-    ├── Building/            ✅ BuildMenuController, BuildMenuDataSource
-    ├── Dialogue/            ⬜ offen (Phase 7)
-    ├── Quest/               ⬜ offen (Phase 7)
-    ├── Combat/              ✅ implementiert (Phase 8)
-    ├── Inventory/           ✅ InventoryController.cs
-    └── ...                  (bestehend)
-```
+→ Siehe `Assets/_Project/TODO.md`


### PR DESCRIPTION
Created central TODO.md with all open tasks: GitHub issues (#76, #102-#117), manual Inspector TODOs, and 3 smaller technical items not yet tracked as issues. Replaced inline TODO/Future Work sections in GAMEPLAN.md and PROJECT_STRUCTURE.md with references to the new file.

https://claude.ai/code/session_012SfS8HeLhWqPATBUUZs3qD